### PR TITLE
Various fixes for Cheyenne platform

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -146,7 +146,7 @@ case "$MACHINE" in
   "CHEYENNE")
     module list
     nprocs=$(( NNODES_RUN_FCST*PPN_RUN_FCST ))
-    APRUN="mpirun -np $nprocs"
+    APRUN="mpirun -np ${PE_MEMBER01}"
     ;;
 
   "STAMPEDE")

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -145,7 +145,6 @@ case "$MACHINE" in
 
   "CHEYENNE")
     module list
-    nprocs=$(( NNODES_RUN_FCST*PPN_RUN_FCST ))
     APRUN="mpirun -np ${PE_MEMBER01}"
     ;;
 

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -132,8 +132,6 @@ jjob_fp="$2"
 #-----------------------------------------------------------------------
 #
 
-module purge
-
 machine=$(echo_lowercase $MACHINE)
 env_fp="${SR_WX_APP_TOP_DIR}/env/${BUILD_ENV_FN}"
 module use "${SR_WX_APP_TOP_DIR}/env"

--- a/ush/set_extrn_mdl_params.sh
+++ b/ush/set_extrn_mdl_params.sh
@@ -71,7 +71,7 @@ function set_known_sys_dir() {
       known_sys_dir=/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001
       ;;
     "CHEYENNE")
-      known_sys_dir=/glade/p/ral/jntp/UFS_CAM/COMGFS}
+      known_sys_dir=/glade/p/ral/jntp/UFS_CAM/COMGFS
       ;;
     esac
     ;;


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
A few different fixes to get workflow running again on Cheyenne.

 - Fix a typo in set_extrn_mdl_params.sh setting the default system path
 - Remove `module purge` from load_modules_run_task.sh. This no longer causes failures on Cheyenne due to intervening PR #650, but it should be removed anyway as it can cause future issues
 - Fixing the number of processors used in the mpirun command for the weather model on Cheyenne. I am honestly not sure how this was ever working, but this change fixes *most* of the runtime failures currently seen on Cheyenne.

**Note: there are still failures for some cases on Cheyenne; will open an issue detailing that problem shortly**

## TESTS CONDUCTED: 
Ran a set of WE2E tests on Cheyenne. Most tasks succeed, however, there are still lingering failures as mentioned above.

Successful tests:
 - grid_CONUS_25km_GFDLgrid_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
 - grid_GSD_HRRR_AK_50km_ics_RAP_lbcs_RAP_suite_GSD_SAR
 - grid_RRFS_CONUS_13km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
 - grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_GSD_SAR
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_HRRR
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_GSD_SAR
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_GSD_v0
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_HRRR
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1alpha
 - grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
 - grid_RRFS_CONUS_3km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta

Unsuccessful tests (all failed at the run_fcst step):
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_RAP_suite_HRRR
 - grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_CPT_v0
 - grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_2017_gfdlmp
 - grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_v16
 - GST_release_public_v1

Testing on Orion and Jet are in progress.

Will run Hera tests once that machine comes back up.

## DEPENDENCIES:
Will require a change to ufs-srweather-app; will link when that PR is opened.

## ISSUE: 
#663 has technically already been resolved, but this will fully address that specific issue.
