### PR TITLE
Update NOAA-EMC/regional_workflow references to ufs-community/regional_workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -24,7 +24,7 @@ Add any links to external PRs. For example:
 If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the ufs-srweather-app repository (docs/UsersGuide/source) as supporting material.
 
 ## ISSUE (optional): 
-If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/NOAA-EMC/other_repository/pull/63"
+If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63"
 
 ## CONTRIBUTORS (optional): 
 If others have contributed to this work aside from the PR author, list them here

--- a/docs/UsersGuide/source/Chapter3.rst
+++ b/docs/UsersGuide/source/Chapter3.rst
@@ -5,7 +5,7 @@ Configuring the FV3SAR Workflow
 ***************************************
 
 The following steps describe how to create a user-specific configuration
-file in order to un your experiment in a given environment.
+file in order to run your experiment in a given environment.
 
 1. Create a user-specific configuration file named ``config.sh`` in the subdirectory
    ``ush`` under the ``$BASEDIR/regional_workflow`` directory containing appropriate
@@ -46,7 +46,7 @@ file in order to un your experiment in a given environment.
    #
    BASEDIR="/path/to/directory/of/regional_workflow/and/NEMSfv3gfs/clones"
    TMPDIR="/path/to/temporary/work/directories"
-   UPPDIR="/scratch3/BMC/det/beck/FV3-CAM/EMC_post/sorc/ncep_post.fd"
+   UPPDIR="/path/to/UPP/executable/directory"
    CCPP="false"
    #
    CDATE="2018060400"

--- a/update_fork.pl
+++ b/update_fork.pl
@@ -17,7 +17,7 @@
 # 4. If all went well, you should see one of two different messages at the end:
 #    - If your fork is already up-to-date, you should see "Already up-to-date."
 #    - If your fork is not up-to-date, this script initiates a fast-forward merge to bring your fork 
-#      up to date with the develop of the main repository (https://github.com/NOAA-EMC/regional_workflow). 
+#      up to date with the develop of the main repository (https://github.com/ufs-community/regional_workflow). 
 #      Near the end git will print a line of statistics describing what changed, which will look 
 #      something like this:
 #
@@ -55,7 +55,7 @@ print "Please enter your Github username:\n";
    }
 
 print "Username = $username\n";
-my $main_repo = "https://$username\@github.com/NOAA-EMC/regional_workflow.git";
+my $main_repo = "https://$username\@github.com/ufs-community/regional_workflow.git";
 my $fork = "https://$username\@github.com/$username/regional_workflow.git";
 
 # Set main repository as a remote repository named "upstream", per standard git conventions


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update NOAA-EMC/regional_workflow references to ufs-community/regional_workflow.  Remove user-defined reference to EMC_post in documentation.

## DOCUMENTATION:
Documentation updated to reflect changes to the regional_workflow.