### PR TITLE
Update locations of static data on Cheyenne, Hera, and Jet

### DIFF
--- a/ush/machine/cheyenne.sh
+++ b/ush/machine/cheyenne.sh
@@ -68,6 +68,6 @@ NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/nda
 MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen"
-TEST_COMINgfs="/glade/scratch/ketefian/NCO_dirs/COMGFS"
-TEST_EXTRN_MDL_SOURCE_BASEDIR="/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files"
+TEST_PREGEN_BASEDIR=/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen
+TEST_COMINgfs=/glade/p/ral/jntp/UFS_SRW_app/COMGFS
+TEST_EXTRN_MDL_SOURCE_BASEDIR=/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files

--- a/ush/machine/cheyenne.sh
+++ b/ush/machine/cheyenne.sh
@@ -68,6 +68,6 @@ NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/nda
 MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR=/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen
-TEST_COMINgfs=/glade/p/ral/jntp/UFS_SRW_app/COMGFS
-TEST_EXTRN_MDL_SOURCE_BASEDIR=/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files
+TEST_PREGEN_BASEDIR="/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen"
+TEST_COMINgfs="/glade/p/ral/jntp/UFS_SRW_app/COMGFS"
+TEST_EXTRN_MDL_SOURCE_BASEDIR="/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files"

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -73,6 +73,6 @@ MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 # Test Data Locations
 TEST_PREGEN_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen"
 TEST_COMINgfs="/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS"
-TEST_EXTRN_MDL_SOURCE_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/staged_extrn_mdl_files"
+TEST_EXTRN_MDL_SOURCE_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/develop/model_data"
 TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
 TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -71,8 +71,8 @@ NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/nda
 MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR=/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen
-TEST_COMINgfs=/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS
-TEST_EXTRN_MDL_SOURCE_BASEDIR=/scratch2/BMC/det/UFS_SRW_app/staged_extrn_mdl_files
-TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS=/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir
-TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS=/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir
+TEST_PREGEN_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen"
+TEST_COMINgfs="/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS"
+TEST_EXTRN_MDL_SOURCE_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/staged_extrn_mdl_files"
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -71,8 +71,8 @@ NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/nda
 MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR="/scratch2/BMC/det/FV3LAM_pregen"
-TEST_COMINgfs="/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS"
-TEST_EXTRN_MDL_SOURCE_BASEDIR="/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/staged_extrn_mdl_files"
-TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
-TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
+TEST_PREGEN_BASEDIR=/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen
+TEST_COMINgfs=/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS
+TEST_EXTRN_MDL_SOURCE_BASEDIR=/scratch2/BMC/det/UFS_SRW_app/staged_extrn_mdl_files
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS=/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir
+TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS=/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir

--- a/ush/machine/jet.sh
+++ b/ush/machine/jet.sh
@@ -79,6 +79,6 @@ RUN_CMD_FCST="srun"
 RUN_CMD_POST="srun"
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/FV3LAM_pregen
-TEST_COMINgfs=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/COMGFS
-TEST_EXTRN_MDL_SOURCE_BASEDIR=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/staged_extrn_mdl_files
+TEST_PREGEN_BASEDIR="/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/FV3LAM_pregen"
+TEST_COMINgfs="/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/COMGFS"
+TEST_EXTRN_MDL_SOURCE_BASEDIR="/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/staged_extrn_mdl_files"

--- a/ush/machine/jet.sh
+++ b/ush/machine/jet.sh
@@ -79,6 +79,6 @@ RUN_CMD_FCST="srun"
 RUN_CMD_POST="srun"
 
 # Test Data Locations
-TEST_PREGEN_BASEDIR="/mnt/lfs4/BMC/wrfruc/FV3-LAM/pregen"
-TEST_COMINgfs="/lfs1/HFIP/hwrf-data/hafs-input/COMGFS"
-TEST_EXTRN_MDL_SOURCE_BASEDIR="/mnt/lfs1/BMC/gsd-fv3/Gerard.Ketefian/UFS_CAM/staged_extrn_mdl_files"
+TEST_PREGEN_BASEDIR=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/FV3LAM_pregen
+TEST_COMINgfs=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/COMGFS
+TEST_EXTRN_MDL_SOURCE_BASEDIR=/mnt/lfs4/BMC/wrfruc/UFS_SRW_app/staged_extrn_mdl_files


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Several paths in the machine-specific files point to locations in user paths or old locations of static data. This PR updates paths of static data in regional_workflow/ush/machine/ to point to the official, centralized locations on Cheyenne, Hera, and Jet.

## TESTS CONDUCTED: 
Ran the following suite of end-to-end tests on Cheyenne and Jet prior to the latest ufs-weather-model hash update. All passed. This list of tests was chosen because all of these tests are known to succeed on all tested platforms, and this tests a variety of input and boundary condition types.

- grid_CONUS_25km_GFDLgrid_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
- grid_RRFS_CONUS_13km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_HRRR
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_HRRR
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
- grid_RRFS_CONUS_3km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta


On Hera, I ran tests with the latest SRW hash, which included the updated weather model. Because of this, many tests could not be generated due to using old, removed CCPP suites (see issue #668). To get around this issue, I tested with the fixes from #697 incorporated into my branch. With those extra commits, all "get_extrn_ics" and "get_extrn_lbcs" tasks completed successfully, which indicates that all data is in its correct place.

## DEPENDENCIES:
This will require a ufs-srweather-app PR to update the regional_workflow hash, will update when that PR is opened.

## ISSUE (optional): 
Will resolve a few issues in #673, many remain however.

