### PR TITLE
Fix restart_interval in model_configure

### DIFF
--- a/ush/templates/model_configure
+++ b/ush/templates/model_configure
@@ -15,7 +15,7 @@ cpl:                     {{ cpl }}
 calendar:                'julian'
 memuse_verbose:          .false.
 atmos_nthreads:          {{ atmos_nthreads }}
-restart_interval:        {{ restart_interval }}
+restart_interval:        {{ restart_interval }}  -1
 output_1st_tstep_rst:    .false.
 write_dopost:            {{ write_dopost }}
 ideflate:                0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The format of `restart_interval` in `model_configure` was changed. Without the value of -1 next to the restart interval hours, restart files would be generated only once at the specific hour. To get restart files every restart interval hours, -1 should be added to the template.

## TESTS CONDUCTED: 
WE2E tests:
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15_thompson_mynn_lam3km
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- MET_verification
- specify_RESTART_INTERVAL