### PR TITLE
Fix failures on GFS_2017_gfdlmp suites

### DIFF
--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -77,6 +77,7 @@ FV3_GFS_2017_gfdlmp:
     fv_debug: False
     k_split: 6
     n_split: 6
+    nord: 2
     nord_zs_filter: !!python/none
     range_warn: False
     vtdm4: 0.075

--- a/ush/templates/input.nml.FV3
+++ b/ush/templates/input.nml.FV3
@@ -119,7 +119,7 @@
     rf_cutoff = 20.e2
     tau = 5.0
     use_hydro_pressure = .false.
-    vtdm4 = 0.075
+    vtdm4 = 0.02
     warm_start = .false.
     write_restart_with_bcs = .false.
     z_tracer = .true.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Since the new parameter values for divergence damping, introduced in PR #657, cause the failures on the two CCPP suites; `GFS_2017_gfldmp` and `GFS_2017_gfdlmp_regional`, those values are changed back to the original ones only for the two CCPP suites.

## TESTS CONDUCTED: 
WE2E tests:
- community_ensemble_008mems
- community_ensemble_2mems
- get_from_HPSS_ics_FV3GFS_lbcs_FV3GFS_fmt_nemsio (O)
- get_from_HPSS_ics_GSMGFS_lbcs_GSMGFS (O)
- new_ESGgrid (O)
- specify_DOT_OR_USCORE
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp (O)
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_2017_gfdlmp_regional (O)
- grid_RRFS_CONUS_25km_ics_GSMGFS_lbcs_GSMGFS_suite_GFS_2017_gfdlmp 
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2 (O)
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16 (O)
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_RAP_suite_HRRR
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_HRRR_suite_RRFS_v1beta
- grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1alpha

## ISSUE:
- Fixes issue mentioned in #705 
- Fixes some test failures listed in #673

## CONTRIBUTORS: 
@gsketefian 

