### PR TITLE
Tweaks to allow compiler and build_env_fn to be specified in the run_…

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -92,7 +92,9 @@ Usage:
     [verbose=\"...\"] \\
     [machine_file=\"...\"] \\
     [stmp=\"...\"] \\
-    [ptmp=\"...\"]
+    [ptmp=\"...\"] \\
+    [compiler=\"...\"] \\
+    [build_env_fn=\"...\"]
 
 The arguments in brackets are optional.  The arguments are defined as 
 follows:
@@ -204,6 +206,16 @@ argument is not used for any tests that are not in NCO mode.
 ptmp:
 Same as the argument \"stmp\" described above but for setting the 
 experiment variable PTMP for all tests that will run in NCO mode.
+
+compiler:
+Type of compiler to use for the workflow. Options are \"intel\" 
+and \"gnu\". Default is \"intel\",
+
+build_env_fn:
+Specify the build environment (see ufs-srweather-app/envs) to 
+use for the workflow. (e.g. build_cheyenne_gnu.env). If a 
+\"gnu\" compiler is specified, it must also be specified with 
+the \"compiler\" option.
 "
 #
 #-----------------------------------------------------------------------
@@ -240,6 +252,8 @@ valid_args=( \
   "machine_file" \
   "stmp" \
   "ptmp" \
+  "compiler" \
+  "build_env_fn" \
   )
 process_args valid_args "$@"
 #
@@ -670,7 +684,8 @@ Please correct and rerun."
 #
   MACHINE="${machine^^}"
   ACCOUNT="${account}"
-
+  COMPILER=${compiler:-"intel"}
+  BUILD_ENV_FN=${build_env_fn:-"build_${machine}_${COMPILER}.env"}
   EXPT_BASEDIR="${expt_basedir}"
   EXPT_SUBDIR="${test_name}"
   USE_CRON_TO_RELAUNCH=${use_cron_to_relaunch:-"TRUE"}
@@ -692,7 +707,10 @@ Please correct and rerun."
 # subdirectory.
 #
 MACHINE=\"${MACHINE}\"
-ACCOUNT=\"${ACCOUNT}\""
+ACCOUNT=\"${ACCOUNT}\"
+
+COMPILER=\"${COMPILER}\"
+BUILD_ENV_FN=\"${BUILD_ENV_FN}\""
 
   if [ -n "${exec_subdir}" ]; then
     expt_config_str=${expt_config_str}"


### PR DESCRIPTION
This change adds the options to specify a compiler and a build_env_fn in the run_WE2E_tests.sh script.

## TESTS CONDUCTED: 
Tested with SRW built with GNU on cheyenne using the grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1alpha case. 

## DEPENDENCIES:
No dependencies

## DOCUMENTATION:
It looks like the docs need to be updated for the run_WE2E_tests.sh in general.

## ISSUE (optional): 
Addresses issue<710>

Note that the post is still failing due to a bug with GNU compilers addressed in this issue--https://github.com/NOAA-EMC/UPP/issues/456
