### PR TITLE
Add a 3km predefined grid over Indianapolis for testing

### DIFF
--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16.sh
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16.sh
@@ -1,0 +1,27 @@
+#
+# TEST PURPOSE/DESCRIPTION:
+# ------------------------
+#
+# This test is to ensure that the workflow running in community mode 
+# completes successfully on the SUBCONUS_Ind_3km grid using the GFS_v16
+# physics suite with ICs and LBCs derived from the FV3GFS.
+#
+
+RUN_ENVIR="community"
+PREEXISTING_DIR_METHOD="rename"
+
+PREDEF_GRID_NAME="SUBCONUS_Ind_3km"
+CCPP_PHYS_SUITE="FV3_GFS_v16"
+
+EXTRN_MDL_NAME_ICS="FV3GFS"
+FV3GFS_FILE_FMT_ICS="grib2"
+EXTRN_MDL_NAME_LBCS="FV3GFS"
+FV3GFS_FILE_FMT_LBCS="grib2"
+USE_USER_STAGED_EXTRN_FILES="TRUE"
+
+DATE_FIRST_CYCL="20190615"
+DATE_LAST_CYCL="20190615"
+CYCL_HRS=( "18" )
+
+FCST_LEN_HRS="6"
+LBC_SPEC_INTVL_HRS="6"

--- a/tests/WE2E/test_configs/wflow_features/config.new_ESGgrid.sh
+++ b/tests/WE2E/test_configs/wflow_features/config.new_ESGgrid.sh
@@ -2,7 +2,7 @@
 # TEST PURPOSE/DESCRIPTION:
 # ------------------------
 #
-# This test checks the capability of the workflow to have the user 
+# This test checks the capability of the workflow to have the user
 # specify a new grid (as opposed to one of the predefined ones in the
 # workflow) of ESGgrid type.
 
@@ -47,7 +47,7 @@ BLOCKSIZE="13"
 QUILTING="TRUE"
 if [ "$QUILTING" = "TRUE" ]; then
   WRTCMP_write_groups="1"
-  WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))                     
+  WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
   WRTCMP_output_grid="lambert_conformal"
   WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
   WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -279,6 +279,53 @@ case ${PREDEF_GRID_NAME} in
 #
 #-----------------------------------------------------------------------
 #
+# A subconus domain over Indianapolis, Indiana with ~3km cells.  This is
+# mostly for testing on a 3km grid with a small number of cells.
+#
+#-----------------------------------------------------------------------
+#
+"SUBCONUS_Ind_3km")
+
+  GRID_GEN_METHOD="ESGgrid"
+
+  ESGgrid_LON_CTR="-86.16"
+  ESGgrid_LAT_CTR="39.77"
+
+  ESGgrid_DELX="3000.0"
+  ESGgrid_DELY="3000.0"
+
+  ESGgrid_NX="200"
+  ESGgrid_NY="200"
+
+  ESGgrid_PAZI="0.0"
+  
+  ESGgrid_WIDE_HALO_WIDTH="6"
+
+  DT_ATMOS="${DT_ATMOS:-40}"
+
+  LAYOUT_X="${LAYOUT_X:-5}"
+  LAYOUT_Y="${LAYOUT_Y:-5}"
+  BLOCKSIZE="${BLOCKSIZE:-40}"
+
+  if [ "$QUILTING" = "TRUE" ]; then
+    WRTCMP_write_groups="1"
+    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_output_grid="lambert_conformal"
+    WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
+    WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
+    WRTCMP_stdlat1="${ESGgrid_LAT_CTR}"
+    WRTCMP_stdlat2="${ESGgrid_LAT_CTR}"
+    WRTCMP_nx="197"
+    WRTCMP_ny="195"
+    WRTCMP_lon_lwr_left="-89.47120417"
+    WRTCMP_lat_lwr_left="37.07809642"
+    WRTCMP_dx="${ESGgrid_DELX}"
+    WRTCMP_dy="${ESGgrid_DELY}"
+  fi
+  ;;
+#
+#-----------------------------------------------------------------------
+#
 # The RRFS Alaska domain with ~13km cells.
 #
 # Note:

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -27,6 +27,7 @@ valid_vals_PREDEF_GRID_NAME=( \
 "GSD_HRRR_AK_50km" \
 "RRFS_NA_13km" \
 "RRFS_NA_3km" \
+"SUBCONUS_Ind_3km" \
 )
 valid_vals_CCPP_PHYS_SUITE=( \
 "FV3_GFS_2017_gfdlmp" \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR adds a new predefined 3km grid over Indianapolis (grid name is `SUBCONUS_Ind_3km`).  This is a 200 x 200 grid (so much smaller than the 3km CONUS grid, which has 1748 x 1038 points).  It is intended for use in the WE2E tests.  The PR also adds a single WE2E test for this grid.

## TESTS CONDUCTED: 
Successfully ran the new WE2E test (`SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2`) on Hera.

## CONTRIBUTORS (optional): 
@mark-a-potts , @JeffBeck-NOAA 

