### PR TITLE
Add Gaea as a supported platform for the regional_workflow

### DIFF
--- a/modulefiles/tasks/gaea/make_grid.local
+++ b/modulefiles/tasks/gaea/make_grid.local
@@ -1,0 +1,6 @@
+#%Module
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/make_ics.local
+++ b/modulefiles/tasks/gaea/make_ics.local
@@ -1,0 +1,6 @@
+#%Module
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/make_lbcs.local
+++ b/modulefiles/tasks/gaea/make_lbcs.local
@@ -1,0 +1,6 @@
+#%Module
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/run_fcst.local
+++ b/modulefiles/tasks/gaea/run_fcst.local
@@ -1,0 +1,6 @@
+#%Module
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/run_vx.local
+++ b/modulefiles/tasks/gaea/run_vx.local
@@ -1,0 +1,7 @@
+#%Module
+
+module use -a /contrib/anaconda/modulefiles
+module load intel/18.0.5.274
+module load anaconda/latest
+module use -a /contrib/met/modulefiles/
+module load met/10.0.0

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1236,7 +1236,7 @@ DEBUG="FALSE"
 #
 #-----------------------------------------------------------------------
 #
-EXTRA_SLURM_CMD="-v"
+EXTRA_SLURM_CMD=""
 MAKE_GRID_TN="make_grid"
 MAKE_OROG_TN="make_orog"
 MAKE_SFC_CLIMO_TN="make_sfc_climo"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1236,7 +1236,7 @@ DEBUG="FALSE"
 #
 #-----------------------------------------------------------------------
 #
-EXTRA_SLURM_CMD=""
+EXTRA_SLURM_CMD="-v"
 MAKE_GRID_TN="make_grid"
 MAKE_OROG_TN="make_orog"
 MAKE_SFC_CLIMO_TN="make_sfc_climo"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1236,6 +1236,7 @@ DEBUG="FALSE"
 #
 #-----------------------------------------------------------------------
 #
+EXTRA_SLURM_CMD=""
 MAKE_GRID_TN="make_grid"
 MAKE_OROG_TN="make_orog"
 MAKE_SFC_CLIMO_TN="make_sfc_climo"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1236,7 +1236,6 @@ DEBUG="FALSE"
 #
 #-----------------------------------------------------------------------
 #
-EXTRA_SLURM_CMD=""
 MAKE_GRID_TN="make_grid"
 MAKE_OROG_TN="make_orog"
 MAKE_SFC_CLIMO_TN="make_sfc_climo"
@@ -1691,6 +1690,14 @@ MAXTRIES_VX_ENSGRID_PROB_RETOP="1"
 MAXTRIES_VX_ENSPOINT="1"
 MAXTRIES_VX_ENSPOINT_MEAN="1"
 MAXTRIES_VX_ENSPOINT_PROB="1"
+
+#
+#-----------------------------------------------------------------------
+#
+# Allows an extra parameter to be passed to slurm via XML Native
+# command
+#
+SLURM_NATIVE_CMD=""
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -193,7 +193,7 @@ file (template_xml_fp):
   'partition_fcst': ${PARTITION_FCST}
   'queue_fcst': ${QUEUE_FCST}
   'machine': ${MACHINE}
-  'extra_slurm_cmd': ${EXTRA_SLURM_CMD}
+  'slurm_native_cmd': ${SLURM_NATIVE_CMD}
 #
 # Workflow task names.
 #

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -193,6 +193,7 @@ file (template_xml_fp):
   'partition_fcst': ${PARTITION_FCST}
   'queue_fcst': ${QUEUE_FCST}
   'machine': ${MACHINE}
+  'extra_slurm_cmd': ${EXTRA_SLURM_CMD}
 #
 # Workflow task names.
 #

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -73,9 +73,5 @@ RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
 # MET Installation Locations
 # MET Plus is not yet supported on noaacloud
 # Test Data Locations
-#TEST_PREGEN_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen"
-#TEST_COMINgfs="/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS"
 TEST_EXTRN_MDL_SOURCE_BASEDIR="/lustre/f2/dev/Mark.Potts/EPIC/SRW/model_data"
-#TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
-#TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
 

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -x
+
+function file_location() {
+
+  # Return the default location of external model files on disk
+
+  local external_file_fmt external_model location
+
+  external_model=${1}
+  external_file_fmt=${2}
+
+  case ${external_model} in
+
+    "FV3GFS")
+      location='/lustre/f2/dev/Mark.Potts/EPIC/SRW/model_data/FV3GFS/${yyyymmdd}${hh}'
+      ;;
+    *)
+      print_info_msg"\
+        External model \'${external_model}\' does not have a default
+      location on Hera. Will try to pull from HPSS"
+      ;;
+
+  esac
+  echo ${location:-}
+}
+
+
+EXTRN_MDL_SYSBASEDIR_ICS=${EXTRN_MDL_SYSBASEDIR_ICS:-$(file_location \
+  ${EXTRN_MDL_NAME_ICS} \
+  ${FV3GFS_FILE_FMT_ICS})}
+EXTRN_MDL_SYSBASEDIR_LBCS=${EXTRN_MDL_SYSBASEDIR_LBCS:-$(file_location \
+  ${EXTRN_MDL_NAME_LBCS} \
+  ${FV3GFS_FILE_FMT_ICS})}
+
+# System scripts to source to initialize various commands within workflow
+# scripts (e.g. "module").
+if [ -z ${ENV_INIT_SCRIPTS_FPS:-""} ]; then
+  ENV_INIT_SCRIPTS_FPS=( "/etc/profile" )
+fi
+
+
+# Commands to run at the start of each workflow task.
+PRE_TASK_CMDS='{ ulimit -s unlimited; ulimit -a; }'
+
+# Architecture information
+WORKFLOW_MANAGER="rocoto"
+NCORES_PER_NODE=${NCORES_PER_NODE:-36}
+SCHED=${SCHED:-"slurm"}
+QUEUE_DEFAULT=${QUEUE_DEFAULT:-"normal"}
+QUEUE_HPSS=${QUEUE_DEFAULT:-"normal"}
+QUEUE_FCST=${QUEUE_DEFAULT:-"normal"}
+
+# UFS SRW App specific paths
+FIXgsm=${FIXgsm:-"//lustre/f2/dev/Mark.Potts/EPIC/fix/fix_am"}
+FIXaer=${FIXaer:-"/lustre/f2/dev/Mark.Potts/EPIC/fix/fix_aer"}
+FIXlut=${FIXlut:-"/lustre/f2/dev/Mark.Potts/EPIC/fix/fix_lut"}
+TOPO_DIR=${TOPO_DIR:-"/lustre/f2/dev/Mark.Potts/EPIC/fix/fix_orog"}
+SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lustre/f2/dev/Mark.Potts/EPIC/fix/fix_sfc_climo"}
+
+RUN_CMD_SERIAL="time"
+#Run Commands currently differ for GNU/openmpi
+#RUN_CMD_UTILS='mpirun --mca btl tcp,vader,self -np $nprocs'
+#RUN_CMD_FCST='mpirun --mca btl tcp,vader,self -np ${PE_MEMBER01}'
+#RUN_CMD_POST='mpirun --mca btl tcp,vader,self -np $nprocs'
+RUN_CMD_UTILS='srun --mpi=pmi2 -n $nprocs'
+RUN_CMD_FCST='srun --mpi=pmi2 -n ${PE_MEMBER01}'
+RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
+
+# MET Installation Locations
+# MET Plus is not yet supported on noaacloud
+

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 function file_location() {
 
   # Return the default location of external model files on disk
@@ -15,11 +13,6 @@ function file_location() {
 
     "FV3GFS")
       location='/lustre/f2/dev/Mark.Potts/EPIC/SRW/model_data/FV3GFS/${yyyymmdd}${hh}'
-      ;;
-    *)
-      print_info_msg"\
-        External model \'${external_model}\' does not have a default
-      location on Hera. Will try to pull from HPSS"
       ;;
 
   esac
@@ -46,7 +39,7 @@ PRE_TASK_CMDS='{ ulimit -s unlimited; ulimit -a; }'
 
 # Architecture information
 WORKFLOW_MANAGER="rocoto"
-EXTRA_SLURM_CMD="-M c3"
+SLURM_NATIVE_CMD="-M c3"
 NCORES_PER_NODE=${NCORES_PER_NODE:-32}
 SCHED=${SCHED:-"slurm"}
 QUEUE_DEFAULT=${QUEUE_DEFAULT:-"normal"}
@@ -71,7 +64,7 @@ RUN_CMD_FCST='srun --mpi=pmi2 -n ${PE_MEMBER01}'
 RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
 
 # MET Installation Locations
-# MET Plus is not yet supported on noaacloud
+# MET Plus is not yet supported on gaea
 # Test Data Locations
 TEST_EXTRN_MDL_SOURCE_BASEDIR="/lustre/f2/dev/Mark.Potts/EPIC/SRW/model_data"
 

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -46,11 +46,13 @@ PRE_TASK_CMDS='{ ulimit -s unlimited; ulimit -a; }'
 
 # Architecture information
 WORKFLOW_MANAGER="rocoto"
-NCORES_PER_NODE=${NCORES_PER_NODE:-36}
+EXTRA_SLURM_CMD="-M c3"
+NCORES_PER_NODE=${NCORES_PER_NODE:-32}
 SCHED=${SCHED:-"slurm"}
 QUEUE_DEFAULT=${QUEUE_DEFAULT:-"normal"}
 QUEUE_HPSS=${QUEUE_DEFAULT:-"normal"}
 QUEUE_FCST=${QUEUE_DEFAULT:-"normal"}
+WTIME_MAKE_LBCS="00:60:00"
 
 # UFS SRW App specific paths
 FIXgsm=${FIXgsm:-"//lustre/f2/dev/Mark.Potts/EPIC/fix/fix_am"}

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -72,4 +72,10 @@ RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
 
 # MET Installation Locations
 # MET Plus is not yet supported on noaacloud
+# Test Data Locations
+#TEST_PREGEN_BASEDIR="/scratch2/BMC/det/UFS_SRW_app/FV3LAM_pregen"
+#TEST_COMINgfs="/scratch2/NCEPDEV/fv3-cam/noscrub/UFS_SRW_App/COMGFS"
+TEST_EXTRN_MDL_SOURCE_BASEDIR="/lustre/f2/dev/Mark.Potts/EPIC/SRW/model_data"
+#TEST_ALT_EXTRN_MDL_SYSBASEDIR_ICS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
+#TEST_ALT_EXTRN_MDL_SYSBASEDIR_LBCS="/scratch2/BMC/det/UFS_SRW_app/dummy_FV3GFS_sys_dir"
 

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -185,7 +185,9 @@ MODULES_RUN_TASK_FP script.
   {%- endif %}
     <walltime>{{ wtime_make_grid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&MAKE_GRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_GRID_TN;.log</cyclestr></join>
 
@@ -209,7 +211,9 @@ MODULES_RUN_TASK_FP script.
   {%- endif %}
     <walltime>{{ wtime_make_orog }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&MAKE_OROG_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_OROG_TN;.log</cyclestr></join>
 
@@ -237,7 +241,9 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_sfc_climo }}:ppn={{ ppn_make_sfc_climo }}</nodes>
     <walltime>{{ wtime_make_sfc_climo }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&MAKE_SFC_CLIMO_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_SFC_CLIMO_TN;.log</cyclestr></join>
 
@@ -275,7 +281,9 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_get_extrn_ics }}:ppn={{ ppn_get_extrn_ics }}</nodes>
     <walltime>{{ wtime_get_extrn_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&GET_EXTRN_ICS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_ICS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -303,7 +311,9 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_get_extrn_lbcs }}:ppn={{ ppn_get_extrn_lbcs }}</nodes>
     <walltime>{{ wtime_get_extrn_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&GET_EXTRN_LBCS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_LBCS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -338,7 +348,9 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_ics }}:ppn={{ ppn_make_ics }}</nodes>
     <walltime>{{ wtime_make_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&MAKE_ICS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_ICS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -383,7 +395,9 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_lbcs }}:ppn={{ ppn_make_lbcs }}</nodes>
     <walltime>{{ wtime_make_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&MAKE_LBCS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_LBCS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -431,6 +445,8 @@ MODULES_RUN_TASK_FP script.
   {%- else %}
     <nodes>{{ nnodes_run_fcst }}:ppn={{ ppn_run_fcst }}</nodes>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- endif %}
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
   {%- endif %}
     <walltime>{{ wtime_run_fcst }}</walltime>
@@ -484,7 +500,9 @@ later below for other output times.
       <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
+    {%- if machine in ["GAEA"]  %}
       <native>&EXTRA_SLURM_CMD;</native>
+    {%- endif %}
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -539,7 +557,9 @@ for other output times.
         <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
+      {%- if machine in ["GAEA"]  %}
         <native>&EXTRA_SLURM_CMD;</native>
+      {%- endif %}
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
         <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -599,7 +619,9 @@ always zero).
         <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
+      {%- if machine in ["GAEA"]  %}
         <native>&EXTRA_SLURM_CMD;</native>
+      {%- endif %}
         {%- if sub_hourly_post %}
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
         <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
@@ -668,7 +690,9 @@ the <task> tag to be identical to the ones above for other output times.
       <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
+    {%- if machine in ["GAEA"]  %}
       <native>&EXTRA_SLURM_CMD;</native>
+    {%- endif %}
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -712,7 +736,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_ccpa }}:ppn={{ ppn_get_obs_ccpa }}</nodes>
     <walltime>{{ wtime_get_obs_ccpa }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&GET_OBS_CCPA_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_CCPA_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -743,7 +769,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_mrms }}:ppn={{ ppn_get_obs_mrms }}</nodes>
     <walltime>{{ wtime_get_obs_mrms }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&GET_OBS_MRMS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_MRMS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -775,7 +803,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_ndas }}:ppn={{ ppn_get_obs_ndas }}</nodes>
     <walltime>{{ wtime_get_obs_ndas }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&GET_OBS_NDAS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_NDAS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -802,7 +832,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -853,7 +885,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_REFC_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -903,7 +937,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_RETOP_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -953,7 +989,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_03h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -989,7 +1027,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_06h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1025,7 +1065,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_GRIDSTAT_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_24h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1061,7 +1103,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_pointstat }}:ppn={{ ppn_vx_pointstat }}</nodes>
     <walltime>{{ wtime_vx_pointstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_POINTSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_POINTSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1114,7 +1158,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1147,7 +1193,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1180,7 +1228,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1213,7 +1263,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1245,7 +1297,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1276,7 +1330,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1306,7 +1362,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1338,7 +1396,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1370,7 +1430,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1402,7 +1464,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1435,7 +1499,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1467,7 +1533,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1500,7 +1568,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1532,7 +1602,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1564,7 +1636,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1595,7 +1669,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSGRID_PROB_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1627,7 +1703,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint }}:ppn={{ ppn_vx_enspoint }}</nodes>
     <walltime>{{ wtime_vx_enspoint }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSPOINT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1656,7 +1734,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint_mean }}:ppn={{ ppn_vx_enspoint_mean }}</nodes>
     <walltime>{{ wtime_vx_enspoint_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSPOINT_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1685,7 +1765,9 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint_prob }}:ppn={{ ppn_vx_enspoint_prob }}</nodes>
     <walltime>{{ wtime_vx_enspoint_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+  {%- if machine in ["GAEA"]  %}
     <native>&EXTRA_SLURM_CMD;</native>
+  {%- endif %}
     <jobname>&VX_ENSPOINT_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_PROB_TN;_@Y@m@d@H.log</cyclestr></join>
 

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -22,6 +22,7 @@ Parameters needed by the job scheduler.
 <!--
 Workflow task names.
 -->
+<!ENTITY EXTRA_SLURM_CMD           "{{ extra_slurm_cmd }}">
 <!ENTITY MAKE_GRID_TN              "{{ make_grid_tn }}">
 <!ENTITY MAKE_OROG_TN              "{{ make_orog_tn }}">
 <!ENTITY MAKE_SFC_CLIMO_TN         "{{ make_sfc_climo_tn }}">
@@ -184,6 +185,7 @@ MODULES_RUN_TASK_FP script.
   {%- endif %}
     <walltime>{{ wtime_make_grid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&MAKE_GRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_GRID_TN;.log</cyclestr></join>
 
@@ -207,6 +209,7 @@ MODULES_RUN_TASK_FP script.
   {%- endif %}
     <walltime>{{ wtime_make_orog }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&MAKE_OROG_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_OROG_TN;.log</cyclestr></join>
 
@@ -234,6 +237,7 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_sfc_climo }}:ppn={{ ppn_make_sfc_climo }}</nodes>
     <walltime>{{ wtime_make_sfc_climo }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&MAKE_SFC_CLIMO_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_SFC_CLIMO_TN;.log</cyclestr></join>
 
@@ -271,6 +275,7 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_get_extrn_ics }}:ppn={{ ppn_get_extrn_ics }}</nodes>
     <walltime>{{ wtime_get_extrn_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&GET_EXTRN_ICS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_ICS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -298,6 +303,7 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_get_extrn_lbcs }}:ppn={{ ppn_get_extrn_lbcs }}</nodes>
     <walltime>{{ wtime_get_extrn_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&GET_EXTRN_LBCS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_LBCS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -332,6 +338,7 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_ics }}:ppn={{ ppn_make_ics }}</nodes>
     <walltime>{{ wtime_make_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&MAKE_ICS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_ICS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -376,6 +383,7 @@ MODULES_RUN_TASK_FP script.
     <nodes>{{ nnodes_make_lbcs }}:ppn={{ ppn_make_lbcs }}</nodes>
     <walltime>{{ wtime_make_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&MAKE_LBCS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_LBCS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -423,6 +431,7 @@ MODULES_RUN_TASK_FP script.
   {%- else %}
     <nodes>{{ nnodes_run_fcst }}:ppn={{ ppn_run_fcst }}</nodes>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
   {%- endif %}
     <walltime>{{ wtime_run_fcst }}</walltime>
     <jobname>&RUN_FCST_TN;{{ uscore_ensmem_name }}</jobname>
@@ -475,6 +484,7 @@ later below for other output times.
       <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
+      <native>&EXTRA_SLURM_CMD;</native>
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -529,6 +539,7 @@ for other output times.
         <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
+        <native>&EXTRA_SLURM_CMD;</native>
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
         <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -588,6 +599,7 @@ always zero).
         <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
+        <native>&EXTRA_SLURM_CMD;</native>
         {%- if sub_hourly_post %}
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
         <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
@@ -656,6 +668,7 @@ the <task> tag to be identical to the ones above for other output times.
       <nodes>{{ nnodes_run_post }}:ppn={{ ppn_run_post }}</nodes>
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
+      <native>&EXTRA_SLURM_CMD;</native>
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
 
@@ -699,6 +712,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_ccpa }}:ppn={{ ppn_get_obs_ccpa }}</nodes>
     <walltime>{{ wtime_get_obs_ccpa }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&GET_OBS_CCPA_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_CCPA_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -729,6 +743,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_mrms }}:ppn={{ ppn_get_obs_mrms }}</nodes>
     <walltime>{{ wtime_get_obs_mrms }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&GET_OBS_MRMS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_MRMS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -760,6 +775,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_get_obs_ndas }}:ppn={{ ppn_get_obs_ndas }}</nodes>
     <walltime>{{ wtime_get_obs_ndas }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&GET_OBS_NDAS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_NDAS_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -786,6 +802,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -836,6 +853,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_REFC_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -885,6 +903,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_RETOP_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -934,6 +953,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_03h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -969,6 +989,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_06h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1004,6 +1025,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_GRIDSTAT_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_24h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1039,6 +1061,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_pointstat }}:ppn={{ ppn_vx_pointstat }}</nodes>
     <walltime>{{ wtime_vx_pointstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_POINTSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_POINTSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
 
@@ -1091,6 +1114,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1123,6 +1147,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1155,6 +1180,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1187,6 +1213,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1218,6 +1245,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1248,6 +1276,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid }}:ppn={{ ppn_vx_ensgrid }}</nodes>
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1277,6 +1306,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1308,6 +1338,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1339,6 +1370,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_MEAN_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1370,6 +1402,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_03h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1402,6 +1435,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_MEAN_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1433,6 +1467,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_06h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1465,6 +1500,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_mean }}:ppn={{ ppn_vx_ensgrid_mean }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_MEAN_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1496,6 +1532,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_24h_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1527,6 +1564,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1557,6 +1595,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_ensgrid_prob }}:ppn={{ ppn_vx_ensgrid_prob }}</nodes>
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSGRID_PROB_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1588,6 +1627,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint }}:ppn={{ ppn_vx_enspoint }}</nodes>
     <walltime>{{ wtime_vx_enspoint }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSPOINT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1616,6 +1656,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint_mean }}:ppn={{ ppn_vx_enspoint_mean }}</nodes>
     <walltime>{{ wtime_vx_enspoint_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSPOINT_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
 
@@ -1644,6 +1685,7 @@ the <task> tag to be identical to the ones above for other output times.
     <nodes>{{ nnodes_vx_enspoint_prob }}:ppn={{ ppn_vx_enspoint_prob }}</nodes>
     <walltime>{{ wtime_vx_enspoint_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
+    <native>&EXTRA_SLURM_CMD;</native>
     <jobname>&VX_ENSPOINT_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_PROB_TN;_@Y@m@d@H.log</cyclestr></join>
 

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -22,7 +22,7 @@ Parameters needed by the job scheduler.
 <!--
 Workflow task names.
 -->
-<!ENTITY EXTRA_SLURM_CMD           "{{ extra_slurm_cmd }}">
+<!ENTITY SLURM_NATIVE_CMD           "{{ slurm_native_cmd }}">
 <!ENTITY MAKE_GRID_TN              "{{ make_grid_tn }}">
 <!ENTITY MAKE_OROG_TN              "{{ make_orog_tn }}">
 <!ENTITY MAKE_SFC_CLIMO_TN         "{{ make_sfc_climo_tn }}">
@@ -186,7 +186,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_make_grid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&MAKE_GRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_GRID_TN;.log</cyclestr></join>
@@ -212,7 +212,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_make_orog }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&MAKE_OROG_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_OROG_TN;.log</cyclestr></join>
@@ -242,7 +242,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_make_sfc_climo }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&MAKE_SFC_CLIMO_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_SFC_CLIMO_TN;.log</cyclestr></join>
@@ -282,7 +282,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_get_extrn_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&GET_EXTRN_ICS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_ICS_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -312,7 +312,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_get_extrn_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&GET_EXTRN_LBCS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_EXTRN_LBCS_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -349,7 +349,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_make_ics }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&MAKE_ICS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_ICS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -396,7 +396,7 @@ MODULES_RUN_TASK_FP script.
     <walltime>{{ wtime_make_lbcs }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&MAKE_LBCS_TN;{{ uscore_ensmem_name }}</jobname>
     <join><cyclestr>&LOGDIR;/&MAKE_LBCS_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -447,7 +447,7 @@ MODULES_RUN_TASK_FP script.
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- endif %}
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <walltime>{{ wtime_run_fcst }}</walltime>
     <jobname>&RUN_FCST_TN;{{ uscore_ensmem_name }}</jobname>
@@ -501,7 +501,7 @@ later below for other output times.
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
     {%- if machine in ["GAEA"]  %}
-      <native>&EXTRA_SLURM_CMD;</native>
+      <native>&SLURM_NATIVE_CMD;</native>
     {%- endif %}
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
@@ -558,7 +558,7 @@ for other output times.
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
       {%- if machine in ["GAEA"]  %}
-        <native>&EXTRA_SLURM_CMD;</native>
+        <native>&SLURM_NATIVE_CMD;</native>
       {%- endif %}
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
         <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
@@ -620,7 +620,7 @@ always zero).
         <walltime>{{ wtime_run_post }}</walltime>
         <nodesize>&NCORES_PER_NODE;</nodesize>
       {%- if machine in ["GAEA"]  %}
-        <native>&EXTRA_SLURM_CMD;</native>
+        <native>&SLURM_NATIVE_CMD;</native>
       {%- endif %}
         {%- if sub_hourly_post %}
         <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
@@ -691,7 +691,7 @@ the <task> tag to be identical to the ones above for other output times.
       <walltime>{{ wtime_run_post }}</walltime>
       <nodesize>&NCORES_PER_NODE;</nodesize>
     {%- if machine in ["GAEA"]  %}
-      <native>&EXTRA_SLURM_CMD;</native>
+      <native>&SLURM_NATIVE_CMD;</native>
     {%- endif %}
       <jobname>&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#</jobname>
       <join><cyclestr>&LOGDIR;/&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr##fmn#_@Y@m@d@H.log</cyclestr></join>
@@ -737,7 +737,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_get_obs_ccpa }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&GET_OBS_CCPA_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_CCPA_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -770,7 +770,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_get_obs_mrms }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&GET_OBS_MRMS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_MRMS_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -804,7 +804,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_get_obs_ndas }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&GET_OBS_NDAS_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&GET_OBS_NDAS_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -833,7 +833,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -886,7 +886,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_REFC_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -938,7 +938,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_RETOP_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -990,7 +990,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_03h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -1028,7 +1028,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_06h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -1066,7 +1066,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_GRIDSTAT_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_GRIDSTAT_24h_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -1104,7 +1104,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_pointstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_POINTSTAT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_POINTSTAT_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
@@ -1159,7 +1159,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1194,7 +1194,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_03h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1229,7 +1229,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_06h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1264,7 +1264,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_24h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1298,7 +1298,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1331,7 +1331,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1363,7 +1363,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1397,7 +1397,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1431,7 +1431,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_03h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1465,7 +1465,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_03h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_03h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1500,7 +1500,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_06h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1534,7 +1534,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_06h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_06h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1569,7 +1569,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_MEAN_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_MEAN_24h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1603,7 +1603,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_24h_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_24h_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1637,7 +1637,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_REFC_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_REFC_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1670,7 +1670,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_ensgrid_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSGRID_PROB_RETOP_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSGRID_PROB_RETOP_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1704,7 +1704,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_enspoint }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSPOINT_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1735,7 +1735,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_enspoint_mean }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSPOINT_MEAN_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_MEAN_TN;_@Y@m@d@H.log</cyclestr></join>
@@ -1766,7 +1766,7 @@ the <task> tag to be identical to the ones above for other output times.
     <walltime>{{ wtime_vx_enspoint_prob }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
   {%- if machine in ["GAEA"]  %}
-    <native>&EXTRA_SLURM_CMD;</native>
+    <native>&SLURM_NATIVE_CMD;</native>
   {%- endif %}
     <jobname>&VX_ENSPOINT_PROB_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&VX_ENSPOINT_PROB_TN;_@Y@m@d@H.log</cyclestr></join>

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -4,7 +4,7 @@
 valid_vals_RUN_ENVIR=("nco" "community")
 valid_vals_VERBOSE=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_DEBUG=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
-valid_vals_MACHINE=("WCOSS_DELL_P3" "HERA" "ORION" "JET" "ODIN" "CHEYENNE" "STAMPEDE" "LINUX" "MACOS" "NOAACLOUD" "SINGULARITY")
+valid_vals_MACHINE=("WCOSS_DELL_P3" "HERA" "ORION" "JET" "ODIN" "CHEYENNE" "STAMPEDE" "LINUX" "MACOS" "NOAACLOUD" "SINGULARITY" "GAEA")
 valid_vals_SCHED=("slurm" "pbspro" "lsf" "lsfcray" "none")
 valid_vals_FCST_MODEL=("ufs-weather-model" "fv3gfs_aqm")
 valid_vals_WORKFLOW_MANAGER=("rocoto" "none")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add machine specific files to allow the SRW app E2E tests to run successfully on Gaea. These changes include adding a <native> section to the FV3LAM template that specifies a cluster for slurm. This addition is required on Gaea and is not currently supported out of the box by Rocoto. Other machine specific files have been added as well.

## TESTS CONDUCTED: 
E2E tests below have been run successfully with the intel (18)/intelmpi on Gaea
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1alpha

## DEPENDENCIES:
Add any links to external PRs. For example:
- ufs-community/ufs-srweather-app/pull/<236>

## ISSUE (optional): 
- https://github.com/ufs-community/ufs-srweather-app/issues/<235>


