### PR TITLE
Verification task include-list quality mark options

### DIFF
--- a/ush/templates/parm/metplus/EnsembleStat_conus_sfc.conf
+++ b/ush/templates/parm/metplus/EnsembleStat_conus_sfc.conf
@@ -93,6 +93,9 @@ ENSEMBLE_STAT_OUTPUT_PREFIX = {MODEL}_ADPSFC_{OBTYPE}
 PB2NC_CONFIG_FILE = {PARM_BASE}/met_config/PB2NCConfig_wrapped
 ENSEMBLE_STAT_CONFIG_FILE = {PARM_BASE}/met_config/EnsembleStatConfig_wrapped
 
+ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+#ENSEMBLE_STAT_OBS_QUALITY_EXC =
+
 # if True, pb2nc will skip processing a file if the output already exists
 # used to speed up runs and reduce redundancy
 PB2NC_SKIP_IF_OUTPUT_EXISTS = True

--- a/ush/templates/parm/metplus/EnsembleStat_upper_air.conf
+++ b/ush/templates/parm/metplus/EnsembleStat_upper_air.conf
@@ -93,6 +93,9 @@ ENSEMBLE_STAT_OUTPUT_PREFIX = {MODEL}_ADPUPA_{OBTYPE}
 PB2NC_CONFIG_FILE = {PARM_BASE}/met_config/PB2NCConfig_wrapped
 ENSEMBLE_STAT_CONFIG_FILE = {PARM_BASE}/met_config/EnsembleStatConfig_wrapped
 
+ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+#ENSEMBLE_STAT_OBS_QUALITY_EXC =
+
 # if True, pb2nc will skip processing a file if the output already exists
 # used to speed up runs and reduce redundancy
 PB2NC_SKIP_IF_OUTPUT_EXISTS = True

--- a/ush/templates/parm/metplus/PointStat_conus_sfc.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_conus_sfc_mean.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc_mean.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_conus_sfc_prob.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc_prob.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air_mean.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air_mean.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
@@ -91,8 +91,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-
-#POINT_STAT_OBS_QUALITY_INC = 1, 2, 3
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Beginning with METplus 4.1, MET 10.1, observations can be filtered by a list of quality marks in PointStat and EnsembleStat, rather than a simple threshold value as used in PB2NC. This PR changes to make use of this option in the METplus configuration files updated in #695. Default values of 0,1,2,3,9 are used, avoiding prepbufr quality marks 4-8.

## TESTS CONDUCTED: 
WE2E tests MET_ensemble_verification and MET_verification passed on hera. If an earlier version of MET/METplus is used, the new options are passed over.
