### PR TITLE
Replace env with modulefiles in scripts

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -94,7 +94,7 @@ Usage:
     [stmp=\"...\"] \\
     [ptmp=\"...\"] \\
     [compiler=\"...\"] \\
-    [build_env_fn=\"...\"]
+    [build_mod_fn=\"...\"]
 
 The arguments in brackets are optional.  The arguments are defined as 
 follows:
@@ -211,9 +211,9 @@ compiler:
 Type of compiler to use for the workflow. Options are \"intel\" 
 and \"gnu\". Default is \"intel\",
 
-build_env_fn:
-Specify the build environment (see ufs-srweather-app/envs) to 
-use for the workflow. (e.g. build_cheyenne_gnu.env). If a 
+build_mod_fn:
+Specify the build module files (see ufs-srweather-app/modulefiles) to 
+use for the workflow. (e.g. build_cheyenne_gnu). If a 
 \"gnu\" compiler is specified, it must also be specified with 
 the \"compiler\" option.
 "
@@ -253,7 +253,7 @@ valid_args=( \
   "stmp" \
   "ptmp" \
   "compiler" \
-  "build_env_fn" \
+  "build_mod_fn" \
   )
 process_args valid_args "$@"
 #
@@ -685,7 +685,7 @@ Please correct and rerun."
   MACHINE="${machine^^}"
   ACCOUNT="${account}"
   COMPILER=${compiler:-"intel"}
-  BUILD_ENV_FN=${build_env_fn:-"build_${machine}_${COMPILER}.env"}
+  BUILD_MOD_FN=${build_mod_fn:-"build_${machine}_${COMPILER}"}
   EXPT_BASEDIR="${expt_basedir}"
   EXPT_SUBDIR="${test_name}"
   USE_CRON_TO_RELAUNCH=${use_cron_to_relaunch:-"TRUE"}
@@ -710,7 +710,7 @@ MACHINE=\"${MACHINE}\"
 ACCOUNT=\"${ACCOUNT}\"
 
 COMPILER=\"${COMPILER}\"
-BUILD_ENV_FN=\"${BUILD_ENV_FN}\""
+BUILD_MOD_FN=\"${BUILD_MOD_FN}\""
 
   if [ -n "${exec_subdir}" ]; then
     expt_config_str=${expt_config_str}"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -73,12 +73,12 @@ RUN_ENVIR="nco"
 # Path to the LMOD sh file on your Linux system. Is set automatically
 # for supported machines.
 #
-# BUILD_ENV_FN:
-# Name of alternative build environment file to use if using an
+# BUILD_MOD_FN:
+# Name of alternative build module file to use if using an
 # unsupported platform. Is set automatically for supported machines.
 #
-# WFLOW_ENV_FN:
-# Name of alternative workflow environment file to use if using an
+# WFLOW_MOD_FN:
+# Name of alternative workflow module file to use if using an
 # unsupported platform. Is set automatically for supported machines.
 #
 # SCHED:
@@ -142,8 +142,8 @@ ACCOUNT="project_name"
 WORKFLOW_MANAGER="none"
 NCORES_PER_NODE=""
 LMOD_PATH=""
-BUILD_ENV_FN=""
-WFLOW_ENV_FN=""
+BUILD_MOD_FN=""
+WFLOW_MOD_FN=""
 SCHED=""
 PARTITION_DEFAULT=""
 QUEUE_DEFAULT=""

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -73,12 +73,12 @@ RUN_ENVIR: "nco"
 # Path to the LMOD sh file on your Linux system. Is set automatically
 # for supported machines.
 #
-# BUILD_ENV_FN:
-# Name of alternative build environment file to use if using an
+# BUILD_MOD_FN:
+# Name of alternative build module file to use if using an
 # unsupported platform. Is set automatically for supported machines.
 #
-# WFLOW_ENV_FN:
-# Name of alternative workflow environment file to use if using an
+# WFLOW_MOD_FN:
+# Name of alternative workflow module file to use if using an
 # unsupported platform. Is set automatically for supported machines.
 #
 # SCHED:
@@ -142,8 +142,8 @@ ACCOUNT: "project_name"
 WORKFLOW_MANAGER: "none"
 NCORES_PER_NODE: ""
 LMOD_PATH: ""
-BUILD_ENV_FN: ""
-WFLOW_ENV_FN: ""
+BUILD_MOD_FN: ""
+WFLOW_MOD_FN: ""
 SCHED: ""
 PARTITION_DEFAULT: ""
 QUEUE_DEFAULT: ""

--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -149,11 +149,11 @@ expt_name="${EXPT_SUBDIR}"
 #
 #-----------------------------------------------------------------------
 #
-env_fp="${SR_WX_APP_TOP_DIR}/env/${WFLOW_ENV_FN}"
-source "${env_fp}" || print_err_msg_exit "\
-Sourcing platform-specific environment file (env_fp) for the workflow 
+module use "${SR_WX_APP_TOP_DIR}/modulefiles"
+module load "${WFLOW_MOD_FN}" || print_err_msg_exit "\
+Loading platform-specific module file (WFLOW_MOD_FN) for the workflow 
 task failed:
-  env_fp = \"${env_fp}\""
+  WFLOW_MOD_FN = \"${WFLOW_MOD_FN}\""
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -86,18 +86,19 @@ jjob_fp="$2"
 #
 #-----------------------------------------------------------------------
 #
-# Sourcing ufs-srweather-app build env file
+# Loading ufs-srweather-app build module files
 #
 #-----------------------------------------------------------------------
 #
 machine=$(echo_lowercase $MACHINE)
-env_fp="${SR_WX_APP_TOP_DIR}/env/${BUILD_ENV_FN}"
-module use "${SR_WX_APP_TOP_DIR}/env"
-source "${env_fp}" || print_err_msg_exit "\
-Sourcing platform- and compiler-specific environment file (env_fp) for the 
+
+source "${SR_WX_APP_TOP_DIR}/etc/lmod-setup.sh"
+module use "${SR_WX_APP_TOP_DIR}/modulefiles"
+module load "${BUILD_MOD_FN}" || print_err_msg_exit "\
+Sourcing platform- and compiler-specific module file (BUILD_MOD_FN) for the 
 workflow task specified by task_name failed:
   task_name = \"${task_name}\"
-  env_fp = \"${env_fp}\""
+  BUILD_MOD_FN = \"${BUILD_MOD_FN}\""
 #
 #-----------------------------------------------------------------------
 #
@@ -112,7 +113,7 @@ workflow task specified by task_name failed:
 #
 # The regional_workflow repository contains module files for the
 # workflow tasks in the template rocoto XML file for the FV3-LAM work-
-# flow that need modules not loaded in the env_fn above.
+# flow that need modules not loaded in the BUILD_MOD_FN above.
 #
 # The full path to a module file for a given task is
 #

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -368,17 +368,17 @@ def setup():
     #
     #-----------------------------------------------------------------------
     #
-    # Set the names of the build and workflow environment files (if not 
+    # Set the names of the build and workflow module files (if not 
     # already specified by the user).  These are the files that need to be 
     # sourced before building the component SRW App codes and running various 
     # workflow scripts, respectively.
     #
     #-----------------------------------------------------------------------
     #
-    global WFLOW_ENV_FN, BUILD_ENV_FN
+    global WFLOW_MOD_FN, BUILD_MOD_FN
     machine=lowercase(MACHINE)
-    WFLOW_ENV_FN=WFLOW_ENV_FN or f"wflow_{machine}.env"
-    BUILD_ENV_FN=BUILD_ENV_FN or f"build_{machine}_{COMPILER}.env"
+    WFLOW_MOD_FN=WFLOW_MOD_FN or f"wflow_{machine}"
+    BUILD_MOD_FN=BUILD_MOD_FN or f"build_{machine}_{COMPILER}"
     #
     #-----------------------------------------------------------------------
     #

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -523,7 +523,7 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Set the names of the build and workflow environment files (if not 
+# Set the names of the build and workflow module files (if not 
 # already specified by the user).  These are the files that need to be 
 # sourced before building the component SRW App codes and running various 
 # workflow scripts, respectively.
@@ -531,8 +531,8 @@ fi
 #-----------------------------------------------------------------------
 #
 machine=$(echo_lowercase ${MACHINE})
-WFLOW_ENV_FN=${WFLOW_ENV_FN:-"wflow_${machine}.env"}
-BUILD_ENV_FN=${BUILD_ENV_FN:-"build_${machine}_${COMPILER}.env"}
+WFLOW_MOD_FN=${WFLOW_MOD_FN:-"wflow_${machine}"}
+BUILD_MOD_FN=${BUILD_MOD_FN:-"build_${machine}_${COMPILER}"}
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Since 'env' was replaced with 'modulefiles' in https://github.com/ufs-community/ufs-srweather-app/pull/238, the counterpart in the regional workflow should be updated.

## TESTS CONDUCTED: 
- GST 6h test on WCOSS_DELL_P3 with both bash and python.
- WE2E test on WCOSS_DELL_P3:
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15_thompson_mynn_lam3km