### PR TITLE
Bug fixes (grid size + suppress screen output from module load)

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -150,7 +150,7 @@ expt_name="${EXPT_SUBDIR}"
 #-----------------------------------------------------------------------
 #
 module use "${SR_WX_APP_TOP_DIR}/modulefiles"
-module load "${WFLOW_MOD_FN}" || print_err_msg_exit "\
+module load "${WFLOW_MOD_FN}" > /dev/null 2>&1 || print_err_msg_exit "\
 Loading platform-specific module file (WFLOW_MOD_FN) for the workflow 
 task failed:
   WFLOW_MOD_FN = \"${WFLOW_MOD_FN}\""

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -455,7 +455,7 @@ case ${PREDEF_GRID_NAME} in
     WRTCMP_stdlat1="${ESGgrid_LAT_CTR}"
     WRTCMP_stdlat2="${ESGgrid_LAT_CTR}"
     WRTCMP_nx="197"
-    WRTCMP_ny="195"
+    WRTCMP_ny="197"
     WRTCMP_lon_lwr_left="-89.47120417"
     WRTCMP_lat_lwr_left="37.07809642"
     WRTCMP_dx="${ESGgrid_DELX}"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
1) Adjust y-direction size of write-component grid of `SUBCONUS_Ind_3km predefined grid from 195 to 197 (this was just an oversight in PR #725 ).
2) Redirect output of module load in launch script (`launch_FV3LAM_wflow.sh`) to `/dev/null` to avoid unwanted screen output (which was introduced in PR #[238](https://github.com/ufs-community/ufs-srweather-app/pull/238) in ufs-srweather-app and is about how to load the `regional_workflow` environment and is not relevant in this context).

## TESTS CONDUCTED: 
1) Plotted the `SUBCONUS_Ind_3km` grid to ensure it has correct size (it does).
2) Manually ran `launch_FV3LAM_wflow.sh` from the command line to verify that screen output is suppressed (it is).
