### PR TITLE
removed cheyenne-specific crontab editing section

### DIFF
--- a/ush/get_crontab_contents.sh
+++ b/ush/get_crontab_contents.sh
@@ -64,15 +64,6 @@ function get_crontab_contents() {
     __crontab_contents__=$( ${__crontab_cmd__} -l )
   fi
   #
-  # On Cheyenne, the output of the "crontab -l" command contains a 3-line
-  # header (comments) at the top that is not actually part of the user's
-  # cron table.  This needs to be removed to avoid adding an unnecessary
-  # copy of this header to the user's cron table.
-  #
-  if [ "$MACHINE" = "CHEYENNE" ]; then
-    __crontab_contents__=$( printf "%s" "${__crontab_contents__}" | tail -n +4 )
-  fi
-  #
   # Set output variables.
   #
   printf -v ${outvarname_crontab_cmd} "%s" "${__crontab_cmd__}"


### PR DESCRIPTION
The E2E tests are removing pre-existing lines from crontab on Cheyenne and overwriting others. Apparently, Cheyenne previously added 3 additional lines to the output of crontab -l, but after the upgrade, this is no longer the case. The extra logic in get_crontab_contents.sh to start counting lines after 3 on cheyenne has been removed and the E2E tests are now functioning as expected.