### PR TITLE
update staged data dir

### DIFF
--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -48,7 +48,7 @@ QUEUE_FCST=${QUEUE_DEFAULT:-"normal"}
 WTIME_MAKE_LBCS="00:60:00"
 
 # UFS SRW App specific paths
-staged_data_dir="/lustre/f2/dev/Mark.Potts/EPIC/UFS_SRW_App/develop"
+staged_data_dir="/lustre/f2/pdata/ncep/UFS_SRW_App/develop"
 FIXgsm=${FIXgsm:-"${staged_data_dir}/fix/fix_am"}
 FIXaer=${FIXaer:-"${staged_data_dir}/fix/fix_aer"}
 FIXlut=${FIXlut:-"${staged_data_dir}/fix/fix_lut"}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updated staged data file path for Gaea to a common location.

## TESTS CONDUCTED: 
Ran three (`grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`,  `grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`,  `grid_SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`) e2e tests on Gaea successfully. 

## DEPENDENCIES:
None.

## DOCUMENTATION:
No documentation changes are required.
