### PR TITLE
[ens_design_RRFS] Update to MET/METplus configuration and versions

### DIFF
--- a/modulefiles/tasks/cheyenne/run_vx.local
+++ b/modulefiles/tasks/cheyenne/run_vx.local
@@ -1,4 +1,2 @@
 #%Module
 module load pylib_regional_workflow
-module use /glade/p/ral/jntp/MET/MET_releases/modulefiles
-module load met/10.0.0

--- a/modulefiles/tasks/hera/run_vx.local
+++ b/modulefiles/tasks/hera/run_vx.local
@@ -3,5 +3,3 @@
 module use -a /contrib/anaconda/modulefiles
 module load intel/18.0.5.274
 module load anaconda/latest
-module use -a /contrib/met/modulefiles/
-module load met/10.0.0

--- a/modulefiles/tasks/wcoss_dell_p3/run_vx.local
+++ b/modulefiles/tasks/wcoss_dell_p3/run_vx.local
@@ -1,6 +1,3 @@
 #%Module
 
 module unload netcdf
-
-module use /gpfs/dell2/emc/verification/noscrub/emc.metplus/modulefiles
-module load met/10.0.0

--- a/ush/machine/cheyenne.sh
+++ b/ush/machine/cheyenne.sh
@@ -60,8 +60,8 @@ RUN_CMD_FCST='mpirun -np ${PE_MEMBER01}'
 RUN_CMD_POST='mpirun -np $nprocs'
 
 # MET/METplus-Related Paths
-MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/glade/p/ral/jntp/MET/MET_releases/10.0.0"}
-METPLUS_PATH=${METPLUS_PATH:-"/glade/p/ral/jntp/MET/METplus/METplus-4.0.0"}
+MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/glade/p/ral/jntp/MET/MET_releases/10.1.0"}
+METPLUS_PATH=${METPLUS_PATH:-"/glade/p/ral/jntp/MET/METplus/METplus-4.1.0"}
 CCPA_OBS_DIR=${CCPA_OBS_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ccpa/proc"}
 MRMS_OBS_DIR=${MRMS_OBS_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/mrms/proc"}
 NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ndas/proc"}

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -64,7 +64,7 @@ RUN_CMD_POST="srun"
 
 # MET/METplus-Related Paths
 MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/contrib/met/10.1.0"}
-METPLUS_PATH=${METPLUS_PATH:-"/contrib/METplus/METplus-4.0.0"}
+METPLUS_PATH=${METPLUS_PATH:-"/contrib/METplus/METplus-4.1.0"}
 CCPA_OBS_DIR=${CCPA_OBS_DIR:-"/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/ccpa/proc"}
 MRMS_OBS_DIR=${MRMS_OBS_DIR:-"/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/mrms/proc"}
 NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/ndas/proc"}

--- a/ush/machine/orion.sh
+++ b/ush/machine/orion.sh
@@ -58,7 +58,7 @@ RUN_CMD_POST="srun"
 
 # MET/METplus-Related Paths
 MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/apps/contrib/MET/10.1.0"}
-METPLUS_PATH=${METPLUS_PATH:-"/apps/contrib/MET/METplus/METplus-4.0.0"}
+METPLUS_PATH=${METPLUS_PATH:-"/apps/contrib/MET/METplus/METplus-4.1.0"}
 CCPA_OBS_DIR=${CCPA_OBS_DIR:-"/work/noaa/fv3-cam/UFS_SRW_App/develop/obs_data/ccpa/proc"}
 MRMS_OBS_DIR=${MRMS_OBS_DIR:-"/work/noaa/fv3-cam/UFS_SRW_App/develop/obs_data/mrms/proc"}
 NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/work/noaa/fv3-cam/UFS_SRW_App/develop/obs_data/ndas/proc"}

--- a/ush/machine/wcoss_dell_p3.sh
+++ b/ush/machine/wcoss_dell_p3.sh
@@ -69,8 +69,8 @@ RUN_CMD_FCST='mpirun -l -np ${PE_MEMBER01}'
 RUN_CMD_POST="mpirun"
 
 # MET/METplus-Related Paths
-MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/gpfs/dell2/emc/verification/noscrub/emc.metplus/met/10.0.0"}
-METPLUS_PATH=${METPLUS_PATH:-"/gpfs/dell2/emc/verification/noscrub/emc.metplus/METplus/METplus-4.0.0"}
+MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/gpfs/dell2/emc/verification/noscrub/emc.metplus/met/10.1.0"}
+METPLUS_PATH=${METPLUS_PATH:-"/gpfs/dell2/emc/verification/noscrub/emc.metplus/METplus/METplus-4.1.0"}
 CCPA_OBS_DIR=${CCPA_OBS_DIR:-"/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/develop/obs_data/ccpa/proc"}
 MRMS_OBS_DIR=${MRMS_OBS_DIR:-"/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/develop/obs_data/mrms/proc"}
 NDAS_OBS_DIR=${NDAS_OBS_DIR:-"/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/develop/obs_data/ndas/proc"}

--- a/ush/templates/parm/metplus/EnsembleStat_conus_sfc.conf
+++ b/ush/templates/parm/metplus/EnsembleStat_conus_sfc.conf
@@ -53,12 +53,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # False for no time summary, True otherwise
 PB2NC_TIME_SUMMARY_FLAG = False
@@ -93,7 +92,7 @@ ENSEMBLE_STAT_OUTPUT_PREFIX = {MODEL}_ADPSFC_{OBTYPE}
 PB2NC_CONFIG_FILE = {PARM_BASE}/met_config/PB2NCConfig_wrapped
 ENSEMBLE_STAT_CONFIG_FILE = {PARM_BASE}/met_config/EnsembleStatConfig_wrapped
 
-ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #ENSEMBLE_STAT_OBS_QUALITY_EXC =
 
 # if True, pb2nc will skip processing a file if the output already exists

--- a/ush/templates/parm/metplus/EnsembleStat_upper_air.conf
+++ b/ush/templates/parm/metplus/EnsembleStat_upper_air.conf
@@ -53,12 +53,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # False for no time summary, True otherwise
 PB2NC_TIME_SUMMARY_FLAG = False
@@ -93,7 +92,7 @@ ENSEMBLE_STAT_OUTPUT_PREFIX = {MODEL}_ADPUPA_{OBTYPE}
 PB2NC_CONFIG_FILE = {PARM_BASE}/met_config/PB2NCConfig_wrapped
 ENSEMBLE_STAT_CONFIG_FILE = {PARM_BASE}/met_config/EnsembleStatConfig_wrapped
 
-ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+ENSEMBLE_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #ENSEMBLE_STAT_OBS_QUALITY_EXC =
 
 # if True, pb2nc will skip processing a file if the output already exists

--- a/ush/templates/parm/metplus/PointStat_conus_sfc.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_WIND, D_DPT, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise
@@ -91,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_conus_sfc_mean.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc_mean.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise
@@ -91,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_conus_sfc_prob.conf
+++ b/ush/templates/parm/metplus/PointStat_conus_sfc_prob.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise
@@ -91,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_WIND, D_DPT, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise
@@ -91,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air_mean.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air_mean.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise
@@ -91,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
@@ -90,7 +90,7 @@ PB2NC_TIME_SUMMARY_TYPES = min, max, range, mean, stdev, median, p80
 # or the value of the environment variable METPLUS_PARM_BASE if set
 POINT_STAT_CONFIG_FILE ={PARM_BASE}/met_config/PointStatConfig_wrapped
 
-POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9
+POINT_STAT_OBS_QUALITY_INC = 0, 1, 2, 3, 9, NA
 #POINT_STAT_OBS_QUALITY_EXC =
 
 POINT_STAT_CLIMO_MEAN_TIME_INTERP_METHOD = NEAREST

--- a/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
+++ b/ush/templates/parm/metplus/PointStat_upper_air_prob.conf
@@ -69,12 +69,11 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 188, 288, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
 # Leave empty to process all
-# PB2NC_OBS_BUFR_VAR_LIST = POB, QOB, TOB, ZOB, UOB, VOB, PMO, TOCC, TDO, HOVI, D_DPT, D_WDIR, D_WIND, D_RH, D_MIXR, D_PRMSL
-PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, TDO, QOB, UOB, VOB, PWO, TOCC, D_RH, D_DPT, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND
+PB2NC_OBS_BUFR_VAR_LIST = PMO, ZOB, TOB, D_DPT, QOB, UOB, VOB, PWO, TOCC, D_RH, HOVI, CEILING, D_PBL, D_CAPE, MXGS, D_WIND, D_PRMSL
 
 # Mapping of input BUFR variable names to output variables names.
 # The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
-PB2NC_MET_CONFIG_OVERRIDES = obs_bufr_map = [{ key = "HOVI"; val = "VIS"; },{ key = "PMO"; val = "PRMSL"; },{ key = "TDO"; val = "DPT"; }, { key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }, { key = "TOCC"; val = "TCDC"; }];
+PB2NC_OBS_BUFR_MAP = [{ key = "PWO"; val = "PWAT"; },{ key = "MXGS"; val = "GUST"; }, { key = "CEILING"; val = "CEILING"; }]
 
 # For defining the time periods for summarization
 # False for no time summary, True otherwise


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updated machine files to use MET 10.1.0 and METplus 4.1.0 and removed unused module loads from modulefiles. The update in versions allows use of ENSEMBLE_STAT_OBS_QUALITY_INC which is now used and updated to include "NA" to capture observations not using quality marks. Obs BUFR list and map is also updated to use MET-derived variables.

Note, this PR is for the ens_design_RRFS branch.

## TESTS CONDUCTED: 

## ISSUES
Addresses #754 and #696.