### PR TITLE
Bug fix for calculation of number of time steps for each WE2E test

### DIFF
--- a/tests/WE2E/get_WE2Etest_names_subdirs_descs.sh
+++ b/tests/WE2E/get_WE2Etest_names_subdirs_descs.sh
@@ -1337,9 +1337,12 @@ ${test_desc}${stripped_line} "
       num_grid_pts=$(( nx*ny ))
 #
 # Calculate the number of time steps for the test.  Note that FCST_LEN_HRS 
-# is in units of hours while dta is in units of seconds.
+# is in units of hours while dta is in units of seconds.  Also, the factor
+# dta - 1 in the numerator is to cause the division to round up to the
+# nearest integer (adding the denominator minus one to the numerator will
+# make this happen).
 #
-      num_time_steps=$(( FCST_LEN_HRS*3600/dta + 1 ))
+      num_time_steps=$(( (FCST_LEN_HRS*3600 + dta - 1)/dta ))
 #
 # Calculate the absolute cost of the test.
 #
@@ -1403,7 +1406,7 @@ ${test_desc}${stripped_line} "
 
     num_grid_pts=$(( nx*ny ))
     fcst_len_hrs="6"
-    num_time_steps=$(( fcst_len_hrs*3600/dta+ 1 ))
+    num_time_steps=$(( (fcst_len_hrs*3600 + dta - 1)/dta ))
     abs_cost_ref=$(( num_grid_pts*num_time_steps ))
 
     for (( i=0; i<=$((num_prim_tests-1)); i++ )); do


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR fixes a bug in the way the number of time steps (`num_time_steps` in `get_WE2Etest_names_subdirs_descs.sh`) is calculated for each WE2E test when creating the CSV file containing information about the available WE2E tests.

## TESTS CONDUCTED: 
Reran the `run_WE2E_tests.sh` script (which in turn calls `get_WE2Etest_names_subdirs_descs.sh`), and a CSV file containing the adjusted numbers was successfully created.

## DOCUMENTATION:
None needed.
