### PR TITLE
Update Spack Stack Location

### DIFF
--- a/modulefiles/tasks/noaacloud/make_grid.local
+++ b/modulefiles/tasks/noaacloud/make_grid.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/make_ics.local
+++ b/modulefiles/tasks/noaacloud/make_ics.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/make_lbcs.local
+++ b/modulefiles/tasks/noaacloud/make_lbcs.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/make_orog.local
+++ b/modulefiles/tasks/noaacloud/make_orog.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/make_sfc_climo.local
+++ b/modulefiles/tasks/noaacloud/make_sfc_climo.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/run_fcst.local
+++ b/modulefiles/tasks/noaacloud/run_fcst.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c

--- a/modulefiles/tasks/noaacloud/run_post.local
+++ b/modulefiles/tasks/noaacloud/run_post.local
@@ -1,6 +1,6 @@
 #%Module
 
-module use /contrib/spack-stack/apps/srw-app-test/modulefiles/Core
+module use /contrib/spack/apps/ufs-srw-public-v2/modulefiles/Core
 module load stack-intel
 module load stack-intel-oneapi-mpi
 module load netcdf-c


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the Spack Stack location for noaacloud in modulefiles/tasks. 

## TESTS CONDUCTED: 
A subset of the quick tests (see below) were ran in the Jenkins pipeline for AWS, Azure, and GCP. All tests ran successfully to completion. 

`grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`
`grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`
`grid_SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16`

## DEPENDENCIES:
None.

## DOCUMENTATION:
No documentation changes are needed.

## ISSUE (optional): 

## CONTRIBUTORS (optional): 
@natalie-perlin @gspetro-NOAA @mark-a-potts @ulmononian Bruce Kropp