### PR TITLE
Remove un-readable path to system dir on Hera.

### DIFF
--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -3,6 +3,7 @@
 function file_location() {
 
   # Return the default location of external model files on disk
+  # Hera does not currently have any files staged on disk.
 
   local external_file_fmt external_model location
 
@@ -10,13 +11,6 @@ function file_location() {
   external_file_fmt=${2}
 
   location=""
-  case ${external_model} in
-
-    "FV3GFS")
-      location='/scratch1/NCEPDEV/rstprod/com/gfs/prod/gfs.${yyyymmdd}/${hh}/atmos'
-      ;;
-
-  esac
   echo ${location:-}
 
 }


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is a bug fix for running the WE2E tests on Hera. The existence of this path is causing failures after the path has become unreadable.

## TESTS CONDUCTED: 
Tested as a part of another branch. Will run through auto-tests here to test fully.

## DEPENDENCIES:
The code won't pass the build tests without [PR #23](https://github.com/ufs-community/ufs-srweather-app/pull/323) in SRW.

