### PR TITLE
Fixes a problem with adding crontabline when the existing lines have …

### DIFF
--- a/ush/get_crontab_contents.py
+++ b/ush/get_crontab_contents.py
@@ -55,6 +55,9 @@ def get_crontab_contents(called_from_cron):
         __crontab_cmd__="/usr/bin/crontab"
     (_,__crontab_contents__,_)=run_command(f'''{__crontab_cmd__} -l''')
   
+    # replace single quotes (hopefully in comments) with double quotes
+    __crontab_contents__ = __crontab_contents__.replace("'", '"')
+
     return __crontab_cmd__, __crontab_contents__
 
 def add_crontab_line():

--- a/ush/setup.py
+++ b/ush/setup.py
@@ -329,7 +329,7 @@ def setup():
     SRC_DIR = os.path.join(SR_WX_APP_TOP_DIR,"src")
     PARMDIR = os.path.join(HOMErrfs,"parm")
     MODULES_DIR = os.path.join(HOMErrfs,"modulefiles")
-    EXECDIR = os.path.join(SR_WX_APP_TOP_DIR,"bin")
+    EXECDIR = os.path.join(SR_WX_APP_TOP_DIR,EXEC_SUBDIR)
     TEMPLATE_DIR = os.path.join(USHDIR,"templates")
     VX_CONFIG_DIR = os.path.join(TEMPLATE_DIR,"parm")
     METPLUS_CONF = os.path.join(TEMPLATE_DIR,"parm","metplus")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Current develop does not run ci lables `ci-intel-hera-WE` and `ci-intel-jet-WE` because the existing cron lines have comments with single quotes e.g "Eric's". This messes up commands like
```
printf "%s" 'crontab_contents'  | crontab
```
because the crontab content is surrounded by single quote. If I use double quotes instead, it leads to a problem where our crontab lines fail to get deleted because they have double quotes that get lost in the process.
My soulution is to keep on using single quotes but replace other instances of single quotes in the existing content with double quotes. Let me know if you think of a better solution.

## TESTS CONDUCTED: 
This PR is the test.

## DEPENDENCIES:
None

## DOCUMENTATION:
None

## ISSUE (optional): 
Fixes issue mentioned in #815 

## CONTRIBUTORS (optional): 
@christinaholtNOAA 

