### PR TITLE
Update default data locations to make "config.community.sh" case work correctly

### DIFF
--- a/ush/machine/cheyenne.sh
+++ b/ush/machine/cheyenne.sh
@@ -13,7 +13,11 @@ function file_location() {
   case ${external_model} in
 
     "FV3GFS")
-      location='/glade/p/ral/jntp/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+      case $external_file_fmt in
+        "grib2")
+          location='/glade/p/ral/jntp/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+          ;;
+      esac
       ;;
 
   esac

--- a/ush/machine/cheyenne.sh
+++ b/ush/machine/cheyenne.sh
@@ -13,7 +13,7 @@ function file_location() {
   case ${external_model} in
 
     "FV3GFS")
-      location='/glade/p/ral/jntp/UFS_CAM/COMGFS/gfs.${yyyymmdd}/${hh}'
+      location='/glade/p/ral/jntp/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
       ;;
 
   esac

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -3,7 +3,6 @@
 function file_location() {
 
   # Return the default location of external model files on disk
-  # Hera does not currently have any files staged on disk.
 
   local external_file_fmt external_model location
 
@@ -11,6 +10,13 @@ function file_location() {
   external_file_fmt=${2}
 
   location=""
+  case ${external_model} in
+
+    "FV3GFS")
+      location='/scratch2/BMC/det/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+      ;;
+
+  esac
   echo ${location:-}
 
 }

--- a/ush/machine/hera.sh
+++ b/ush/machine/hera.sh
@@ -13,7 +13,11 @@ function file_location() {
   case ${external_model} in
 
     "FV3GFS")
-      location='/scratch2/BMC/det/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+      case $external_file_fmt in
+        "grib2")
+          location='/scratch2/BMC/det/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+          ;;
+      esac
       ;;
 
   esac

--- a/ush/machine/orion.sh
+++ b/ush/machine/orion.sh
@@ -11,6 +11,17 @@ function file_location() {
   external_file_fmt=${2}
 
   location=""
+  case ${external_model} in
+
+    "FV3GFS")
+      case $external_file_fmt in
+        "grib2")
+          location='/work/noaa/fv3-cam/UFS_SRW_App/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}'
+          ;;
+      esac
+      ;;
+
+  esac
   echo ${location:-}
 
 }


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
On a few different platforms (Cheyenne, Hera, and Orion), the default case specified in the file `ush/config.community.sh` does not work correctly because the input data can not be found. This PR modifies the default input data location on those platforms so that this test case will succeed "out of the box" (user only needs to specify machine and account) by pointing to the staged data file directories on those respective platforms.

## TESTS CONDUCTED: 
Ran the case specified by `ush/config.community.sh` on Cheyenne, Hera, and Orion; all succeeded after these changes. Also ran it on Jet; this succeeded because the already-specified default location on Jet has the appropriate data.

Did not run any WE2E tests, although this should not change any of those results. Will run for Hera and Jet using CI tags to make sure nothing major has broken.

## DEPENDENCIES:
None

## DOCUMENTATION:
None

