### PR TITLE
Bugfix with machine file wrapper.

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -95,9 +95,9 @@ fi
 #-----------------------------------------------------------------------
 #
 . $exptdir/var_defns.sh
+. $USHDIR/source_util_funcs.sh
 . $USHDIR/source_machine_file.sh
 . $USHDIR/constants.sh
-. $USHDIR/source_util_funcs.sh
 . $USHDIR/init_env.sh
 #
 #-----------------------------------------------------------------------

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -8,8 +8,8 @@
 #-----------------------------------------------------------------------
 #
 . ${GLOBAL_VAR_DEFNS_FP}
-. $USHDIR/source_machine_file.sh
 . $USHDIR/source_util_funcs.sh
+. $USHDIR/source_machine_file.sh
 . $USHDIR/init_env.sh
 #
 #-----------------------------------------------------------------------


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Machine file wrapper `source_machine_file.sh` uses `save/restore_shell_opts` but those are not defined when it is called from 
`load_module_run_task` and `launch_FV3LAM_wflow` because bash utilities are sourced after the machine file.
A simple change in order of sourcing these files should fix it. After this fix, i was able to use `set -e` for all scripts.

## TESTS CONDUCTED: 
Run one test on hera manually, will run automated test later.


