### PR TITLE
Use new MET/METplus installs on Gaea

### DIFF
--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -66,5 +66,11 @@ RUN_CMD_FCST='srun --mpi=pmi2 -n ${PE_MEMBER01}'
 RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
 
 # MET Installation Locations
-# MET Plus is not yet supported on gaea
+MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/usw/met/10.1.2"}
+METPLUS_PATH=${METPLUS_PATH:-"/usw/met/METplus/METplus-4.1.3"}
+CCPA_OBS_DIR=${CCPA_OBS_DIR:-"${staged_data_dir}/obs_data/ccpa/proc"}
+MRMS_OBS_DIR=${MRMS_OBS_DIR:-"${staged_data_dir}/obs_data/mrms/proc"}
+NDAS_OBS_DIR=${NDAS_OBS_DIR:-"${staged_data_dir}/obs_data/ndas/proc"}
+MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
+
 # Test Data Locations

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -48,7 +48,7 @@ QUEUE_FCST=${QUEUE_DEFAULT:-"normal"}
 WTIME_MAKE_LBCS="00:60:00"
 
 # UFS SRW App specific paths
-staged_data_dir="/lustre/f2/pdata/ncep/UFS_SRW_App/develop"
+staged_data_dir="/lustre/f2/pdata/ncep_shared/UFS_SRW_App/develop"
 FIXgsm=${FIXgsm:-"${staged_data_dir}/fix/fix_am"}
 FIXaer=${FIXaer:-"${staged_data_dir}/fix/fix_aer"}
 FIXlut=${FIXlut:-"${staged_data_dir}/fix/fix_lut"}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Recent versions of MET/METplus were installed on Gaea (https://dtcenter.org/community-code/metplus/metplus-4-1-existing-builds). This PR adds theirs paths to the Gaea machine file, which should enable their use in the workflow.

## TESTS CONDUCTED: 
`MET_ensemble_verification` and `MET_verification` tests need to be run on Gaea by someone with access to the platform and it needs to be confirmed that observations are staged in /lustre/f2/pdata/ncep_shared/UFS_SRW_App/develop/obs_data. Other platforms should not be impacted.

Once this is successfully tested and merged, @jessemcfarland should be able to remove the logic in https://github.com/ufs-community/ufs-srweather-app/pull/333 that avoids running the verification tests on Gaea.


