### PR TITLE
corrected path to miniconda3 regional_workflow environment in noaacloud.sh 

### DIFF
--- a/ush/machine/noaacloud.sh
+++ b/ush/machine/noaacloud.sh
@@ -20,9 +20,9 @@ function file_location() {
   esac
   echo ${location:-}
 }
-export PROJ_LIB=/contrib/GST/miniconda/envs/regional_workflow/share/proj
+export PROJ_LIB=/contrib/GST/miniconda3/4.10.3/envs/regional_workflow/share/proj
 export OPT=/contrib/EPIC/hpc-modules
-export PATH=${PATH}:/contrib/GST/miniconda/envs/regional_workflow/bin
+export PATH=${PATH}:/contrib/GST/miniconda3/4.10.3/envs/regional_workflow/bin
 
 EXTRN_MDL_SYSBASEDIR_ICS=${EXTRN_MDL_SYSBASEDIR_ICS:-$(file_location \
   ${EXTRN_MDL_NAME_ICS} \
@@ -71,4 +71,4 @@ BUILD_MOD_FN="wflow_noaacloud"
 
 # MET Installation Locations
 # MET Plus is not yet supported on noaacloud
-. /contrib/EPIC/.bash_conda
+#. /contrib/EPIC/.bash_conda 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 

The outdated path of the regional_workflow conda environment in cloud platforms (./ush/machine/noaacloud.sh) created errors when running tests. 

1) Corrected the environmental variables PROJ_LIB and PATH to list the correct path to the regional_workflow of the miniconda3 module.
2) commented out the last line of the noaacloud.sh machine file; not needed when the path to the regional_workflow conda environment is fixed.

Tested on AWS and Azure cloud platforms, by running 20 tests from the comprehensive test list on each platform.

## TESTS CONDUCTED: 

Tested the SRW (ufs-srweather-app) with the update regional_workflow code on AWS and Azure platforms, using 20 tests on each cluster. The following tests have been run:

grid_RRFS_CONUScompact_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_SUBCONUS_Ind_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_HRRR
grid_SUBCONUS_Ind_3km_ics_HRRR_lbcs_RAP_suite_WoFS_v0
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
grid_RRFS_CONUScompact_13km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
grid_RRFS_CONUScompact_3km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
grid_RRFS_CONUScompact_25km_ics_HRRR_lbcs_RAP_suite_HRRR
grid_RRFS_CONUScompact_13km_ics_HRRR_lbcs_RAP_suite_HRRR
grid_RRFS_CONUScompact_3km_ics_HRRR_lbcs_RAP_suite_HRRR
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1beta
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_HRRR
grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1beta
grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_HRRR
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1beta
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_HRRR

(All the tests either successfully completed at the moment of writing, or running as expected)


