### PR TITLE
Release/public v2 gaea update

### DIFF
--- a/modulefiles/module-setup.csh.inc
+++ b/modulefiles/module-setup.csh.inc
@@ -56,6 +56,8 @@ else if ( { test -d /lustre -a -d /ncrc } ) then
         # the module command fails.  Hence we actually have to source
         # /etc/csh.login here.
         source /etc/csh.login
+        # initialize Lmod/8.7.12 using a wrapper script
+        source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
         set __ms_source_etc_csh_login=yes
     else
         set __ms_source_etc_csh_login=no

--- a/modulefiles/module-setup.sh.inc
+++ b/modulefiles/module-setup.sh.inc
@@ -66,6 +66,8 @@ elif [[ -d /lustre && -d /ncrc ]] ; then
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
         source /etc/profile
+        # initialize Lmod/8.7.12 using a wrapper script
+        source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
         __ms_source_etc_profile=yes
     else
         __ms_source_etc_profile=no

--- a/modulefiles/tasks/gaea/get_extrn_ics.local
+++ b/modulefiles/tasks/gaea/get_extrn_ics.local
@@ -1,0 +1,7 @@
+#%Module
+  
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/get_extrn_lbcs.local
+++ b/modulefiles/tasks/gaea/get_extrn_lbcs.local
@@ -1,0 +1,7 @@
+#%Module
+  
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/make_grid.local
+++ b/modulefiles/tasks/gaea/make_grid.local
@@ -1,5 +1,6 @@
 #%Module
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
 module load rocoto
 module load miniconda3
 

--- a/modulefiles/tasks/gaea/make_ics.local
+++ b/modulefiles/tasks/gaea/make_ics.local
@@ -1,5 +1,6 @@
 #%Module
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
 module load rocoto
 module load miniconda3
 

--- a/modulefiles/tasks/gaea/make_lbcs.local
+++ b/modulefiles/tasks/gaea/make_lbcs.local
@@ -1,5 +1,6 @@
 #%Module
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
 module load rocoto
 module load miniconda3
 

--- a/modulefiles/tasks/gaea/make_orog.local
+++ b/modulefiles/tasks/gaea/make_orog.local
@@ -1,0 +1,7 @@
+#%Module
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/make_sfc_climo.local
+++ b/modulefiles/tasks/gaea/make_sfc_climo.local
@@ -1,0 +1,7 @@
+#%Module
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/run_fcst.local
+++ b/modulefiles/tasks/gaea/run_fcst.local
@@ -1,5 +1,5 @@
 #%Module
-module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
 module load rocoto
 module load miniconda3
 

--- a/modulefiles/tasks/gaea/run_post.local
+++ b/modulefiles/tasks/gaea/run_post.local
@@ -1,0 +1,7 @@
+#%Module
+
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/run_vx.local
+++ b/modulefiles/tasks/gaea/run_vx.local
@@ -1,6 +1,8 @@
 #%Module
+  
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
 
-module load intel/19.0.5.281
-module use /usw/met/METplus/modulefiles
-module load metplus/4.1.3
-module load python/3.9
+prepend-path LD_LIBRARY_PATH /ncrc/sw/gaea-cle7/python/3.9/anaconda-base/envs/noaa_py3.9/lib
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/gaea/run_vx.local
+++ b/modulefiles/tasks/gaea/run_vx.local
@@ -1,7 +1,6 @@
 #%Module
 
-module use -a /contrib/anaconda/modulefiles
-module load intel/18.0.5.274
-module load anaconda/latest
-module use -a /contrib/met/modulefiles/
-module load met/10.0.0
+module load intel/19.0.5.281
+module use /usw/met/METplus/modulefiles
+module load metplus/4.1.3
+module load python/3.9

--- a/modulefiles/tasks/get_extrn_lbcs.local
+++ b/modulefiles/tasks/get_extrn_lbcs.local
@@ -1,7 +1,0 @@
-#%Module
-  
-module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
-module load rocoto
-module load miniconda3
-
-setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/get_extrn_lbcs.local
+++ b/modulefiles/tasks/get_extrn_lbcs.local
@@ -1,0 +1,7 @@
+#%Module
+  
+module use /lustre/f2/dev/wpo/role.epic/contrib/modulefiles
+module load rocoto
+module load miniconda3
+
+setenv SRW_ENV regional_workflow

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -92,7 +92,7 @@ jjob_fp="$2"
 #
 machine=$(echo_lowercase $MACHINE)
 
-source "${SR_WX_APP_TOP_DIR}/etc/lmod-setup.sh"
+source "${SR_WX_APP_TOP_DIR}/etc/lmod-setup.sh ${machine}"
 module use "${SR_WX_APP_TOP_DIR}/modulefiles"
 module load "${BUILD_MOD_FN}" || print_err_msg_exit "\
 Loading of platform- and compiler-specific module file (BUILD_MOD_FN) 

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -92,7 +92,7 @@ jjob_fp="$2"
 #
 machine=$(echo_lowercase $MACHINE)
 
-source "${SR_WX_APP_TOP_DIR}/etc/lmod-setup.sh ${machine}"
+source "${SR_WX_APP_TOP_DIR}/etc/lmod-setup.sh" ${machine}
 module use "${SR_WX_APP_TOP_DIR}/modulefiles"
 module load "${BUILD_MOD_FN}" || print_err_msg_exit "\
 Loading of platform- and compiler-specific module file (BUILD_MOD_FN) 

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -68,5 +68,10 @@ RUN_CMD_FCST='srun --mpi=pmi2 -n ${PE_MEMBER01}'
 RUN_CMD_POST='srun --mpi=pmi2 -n $nprocs'
 
 # MET Installation Locations
-# MET Plus is not yet supported on gaea
+MET_INSTALL_DIR=${MET_INSTALL_DIR:-"/usw/met/10.1.2"}
+METPLUS_PATH=${METPLUS_PATH:-"/usw/met/METplus/METplus-4.1.3"}
+CCPA_OBS_DIR=${CCPA_OBS_DIR:-"${staged_data_dir}/obs_data/ccpa/proc"}
+MRMS_OBS_DIR=${MRMS_OBS_DIR:-"${staged_data_dir}/obs_data/mrms/proc"}
+NDAS_OBS_DIR=${NDAS_OBS_DIR:-"${staged_data_dir}/obs_data/ndas/proc"}
+MET_BIN_EXEC=${MET_BIN_EXEC:-"bin"}
 # Test Data Locations

--- a/ush/machine/gaea.sh
+++ b/ush/machine/gaea.sh
@@ -19,6 +19,8 @@ function file_location() {
   echo ${location:-}
 }
 
+export PROJ_LIB=/lustre/f2/dev/role.epic/contrib/miniconda3/4.12.0/envs/regional_workflow/share/proj
+export PATH=${PATH}:/lustre/f2/deve/role.epic/contrib/miniconda3/4.12.0/envs/regional_workflow/bin
 
 EXTRN_MDL_SYSBASEDIR_ICS=${EXTRN_MDL_SYSBASEDIR_ICS:-$(file_location \
   ${EXTRN_MDL_NAME_ICS} \
@@ -30,7 +32,7 @@ EXTRN_MDL_SYSBASEDIR_LBCS=${EXTRN_MDL_SYSBASEDIR_LBCS:-$(file_location \
 # System scripts to source to initialize various commands within workflow
 # scripts (e.g. "module").
 if [ -z ${ENV_INIT_SCRIPTS_FPS:-""} ]; then
-  ENV_INIT_SCRIPTS_FPS=( "/etc/profile" )
+  ENV_INIT_SCRIPTS_FPS=( "/etc/profile"  "/lustre/f2/dev/role.epic/contrib/Lmod_init.sh" )
 fi
 
 


### PR DESCRIPTION
This update is for backward compatibility with the SRW _**release/public-v2**_ branch of the SRW App, 
https://github.com/ufs-community/ufs-srweather-app.git.

Changes are made to reflect updates in Lmod/8.7.12, miniconda3, and the hpc-stack on Gaea NOAA HPC system, installed under **epic.role** account in **/lustre/f2/dev/wpo/role.epic/contrib/** space, and maintained by EPIC.


** FILES CHANGED

The following scripts have been changed under the ./regional_workflow/ base directory:

./ush/machine/gaea.sh
./ush/load_modules_run_task.sh (contribution of @EdwardSnyder-NOAA )
./modulefiles/module-setup.sh.inc
./modulefiles/module-setup.csh.inc
./modulefiles/tasks/gaea/make_grid.local, get_extrn_ics.local, get_extrn_lbcs.local, make_orog.local, make_sfc_climo.local, make_ics.local, make_lbcs.local, run_fcst.local, run_post.local  (contribution of @EdwardSnyder-NOAA )


** TESTING PERFORMED 

The updated repository has been tested on Gaea as a part of the SRW release/public-v2 branch, 
by specifying the url for the regional_workflow in the Externals.cfg as following:

```
[regional_workflow]
protocol = git
#repo_url = https://github.com/ufs-community/regional_workflow
repo_url = https://github.com/natalie-perlin/regional_workflow
# Specify either a branch name or a hash but not both.
branch = release/public-v2-gaea-update
local_path = regional_workflow
required = True
...

```
Additional files in the SRW release/public-v2 branch were modified to sync the updated Lmod/8.7.12, miniconda3/4.12.0 and the hpc-stack initialization, under the main SRW directory, such as **./ufs-srweather-app/**:

./etc/lmod-setup.sh , lmod-setup.csh
./modulefiles/build_gaea_intel
./modulefiles/wflow_gaea

These updates of the SRW **release/public-v2** branch are being prepared as a separate PR into the 
https://github.com/ufs-community/ufs-srweather-app.git, to correspond the current changes to the regional_workflow repo, release/public-v2 branch.

The SRW has been build, and a test case grid_RRFS_CONUScompact_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16 from the comprehensive test suite has been run using the rocoto and crontab table. The following stages have been successfully completed: 
make_grid 
make_orog
make_sfc_climo
get_extrn_ics
get_extrn_lbcs
make_ics
make_lbcs
run_fcst
run_post_f001 - run_post_f006.


